### PR TITLE
Fixed health bars bug

### DIFF
--- a/Penteract/Assets/Scripts/PlayerController.cpp
+++ b/Penteract/Assets/Scripts/PlayerController.cpp
@@ -385,8 +385,12 @@ void PlayerController::Update() {
 	if (!hudControllerScript) return;
 
 	if (firstTime) {
-		hudControllerScript->UpdateHP(lifePointsFang, lifePointsOni);
-		hudControllerScript->UpdateHP(lifePointsOni, lifePointsFang);
+		if (fang->IsActive()) {
+			hudControllerScript->UpdateHP(lifePointsFang, lifePointsOni);
+		}
+		else {
+			hudControllerScript->UpdateHP(lifePointsOni, lifePointsFang);
+		}
 		firstTime = false;
 	}
 

--- a/Penteract/Assets/Scripts/PlayerController.cpp
+++ b/Penteract/Assets/Scripts/PlayerController.cpp
@@ -236,11 +236,13 @@ void PlayerController::SwitchCharacter() {
 			Debug::Log("Swaping to onimaru...");
 			fang->Disable();
 			onimaru->Enable();
+			hudControllerScript->UpdateHP(lifePointsOni, lifePointsFang);
 		}
 		else {
 			Debug::Log("Swaping to fang...");
 			onimaru->Disable();
 			fang->Enable();
+			hudControllerScript->UpdateHP(lifePointsFang, lifePointsOni);
 		}
 		switchCooldownRemaing = switchCooldown;
 	}
@@ -384,6 +386,7 @@ void PlayerController::Update() {
 
 	if (firstTime) {
 		hudControllerScript->UpdateHP(lifePointsFang, lifePointsOni);
+		hudControllerScript->UpdateHP(lifePointsOni, lifePointsFang);
 		firstTime = false;
 	}
 


### PR DESCRIPTION
The health bars were not displaying the right health until the first hit after performing the switch ability.
After a switch, we need to update the character HP HUD

Also edited first time conditional in Update function so if we start the level with Onimaru, the health displayed is Onimaru's and not Fang's

