### PR TITLE
Feature/cu kxd69k camera smoothness

### DIFF
--- a/Penteract/Assets/Scripts/PlayerController.cpp
+++ b/Penteract/Assets/Scripts/PlayerController.cpp
@@ -48,7 +48,9 @@ EXPOSE_MEMBERS(PlayerController) {
 		MEMBER(MemberType::FLOAT, onimaruMovementSpeed),
 		MEMBER(MemberType::FLOAT, shootCooldown),
 		MEMBER(MemberType::INT, lifePointsFang),
-		MEMBER(MemberType::INT, lifePointsOni)
+		MEMBER(MemberType::INT, lifePointsOni),
+		MEMBER(MemberType::BOOL, useSmoothCamera),
+		MEMBER(MemberType::FLOAT, smoothCameraSpeed)
 
 };
 
@@ -474,10 +476,15 @@ void PlayerController::UpdatePlayerStats() {
 
 void PlayerController::UpdateCameraPosition() {
 	float3 playerGlobalPos = transform->GetGlobalPosition();
-	cameraTransform->SetGlobalPosition(float3(
-		playerGlobalPos.x + cameraOffsetX,
-		playerGlobalPos.y + cameraOffsetY,
-		playerGlobalPos.z + cameraOffsetZ));
+
+	float3 desiredPosition = playerGlobalPos + float3(cameraOffsetX, cameraOffsetY, cameraOffsetZ);
+	float3 smoothedPosition = desiredPosition;
+
+	if (useSmoothCamera) {
+		smoothedPosition = float3::Lerp(cameraTransform->GetGlobalPosition(), desiredPosition, smoothCameraSpeed * Time::GetDeltaTime());
+	}
+	
+	cameraTransform->SetGlobalPosition(smoothedPosition);
 }
 
 void PlayerController::Update() {

--- a/Penteract/Assets/Scripts/PlayerController.h
+++ b/Penteract/Assets/Scripts/PlayerController.h
@@ -84,6 +84,10 @@ public:
 	float shootCooldown = 0.1f;
 	bool firstTime = true;
 
+	//Camera
+	bool useSmoothCamera = true;
+	float smoothCameraSpeed = 5.0f;
+
 	std::vector<std::string> states{ "Idle" ,
 								"RunBackward" , "RunForward" , "RunLeft" , "RunRight" ,
 								"DashBackward", "DashForward" , "DashLeft" , "DashRight" ,


### PR DESCRIPTION
Now camera can follow the player smoothly.

Two variables can be set from the PlayerController script:
- UseSmoothCamera: if true, will follow the player with a delayed position.
- SmoothCameraSpeed: the smaller, the more delayed the camera is. Currently at 5.0f.