### PR TITLE
Make enemies rotate towards movement

### DIFF
--- a/Penteract/Assets/Scripts/AIMovement.cpp
+++ b/Penteract/Assets/Scripts/AIMovement.cpp
@@ -68,7 +68,7 @@ void AIMovement::Seek(AIState state, const float3& newPosition, int speed, bool 
 
 	if (state != AIState::START && orientateToDir) {
 		targetRotation = Quat::LookAt(float3(0, 0, 1), velocity.Normalized(), float3(0, 1, 0), float3(0, 1, 0));
-		Quat rotation = Quat::Slerp(ownerTransform->GetGlobalRotation(), targetRotation, rotationSmoothness * Time::GetDeltaTime());
+		Quat rotation = Quat::Slerp(ownerTransform->GetGlobalRotation(), targetRotation, Min(Time::GetDeltaTime() / Max(rotationSmoothness, 0.000001f), 1.0f));
 		ownerTransform->SetGlobalRotation(rotation);
 	}
 }

--- a/Penteract/Assets/Scripts/AIMovement.cpp
+++ b/Penteract/Assets/Scripts/AIMovement.cpp
@@ -7,7 +7,7 @@
 int AIMovement::maxAcceleration = 9999;
 
 EXPOSE_MEMBERS(AIMovement) {
-	MEMBER(MemberType::FLOAT, rotationSlerpRatio)
+	MEMBER(MemberType::FLOAT, rotationSmoothness)
 };
 
 GENERATE_BODY_IMPL(AIMovement);
@@ -68,7 +68,7 @@ void AIMovement::Seek(AIState state, const float3& newPosition, int speed, bool 
 
 	if (state != AIState::START && orientateToDir) {
 		targetRotation = Quat::LookAt(float3(0, 0, 1), velocity.Normalized(), float3(0, 1, 0), float3(0, 1, 0));
-		Quat rotation = Quat::Slerp(ownerTransform->GetGlobalRotation(), targetRotation, rotationSlerpRatio * Time::GetDeltaTime());
+		Quat rotation = Quat::Slerp(ownerTransform->GetGlobalRotation(), targetRotation, rotationSmoothness * Time::GetDeltaTime());
 		ownerTransform->SetGlobalRotation(rotation);
 	}
 }

--- a/Penteract/Assets/Scripts/AIMovement.cpp
+++ b/Penteract/Assets/Scripts/AIMovement.cpp
@@ -7,7 +7,7 @@
 int AIMovement::maxAcceleration = 9999;
 
 EXPOSE_MEMBERS(AIMovement) {
-
+	MEMBER(MemberType::FLOAT, rotationSlerpRatio)
 };
 
 GENERATE_BODY_IMPL(AIMovement);
@@ -55,21 +55,21 @@ void AIMovement::Seek(AIState state, const float3& newPosition, int speed, bool 
 	float3 position = ownerTransform->GetGlobalPosition();
 	float3 direction = newPosition - position;
 
-	velocity = direction.Normalized() * speed;
-
-	position += velocity * Time::GetDeltaTime();
-
 	if (state == AIState::START) {
+		velocity = direction.Normalized() * speed;
+		position += velocity * Time::GetDeltaTime();
 		ownerTransform->SetGlobalPosition(position);
 	} else {
 		if (agent) {
 			agent->SetMoveTarget(newPosition, true);
+			velocity = agent->GetVelocity();
 		}
 	}
 
 	if (state != AIState::START && orientateToDir) {
-		Quat newRotation = Quat::LookAt(float3(0, 0, 1), direction.Normalized(), float3(0, 1, 0), float3(0, 1, 0));
-		ownerTransform->SetGlobalRotation(newRotation);
+		targetRotation = Quat::LookAt(float3(0, 0, 1), velocity.Normalized(), float3(0, 1, 0), float3(0, 1, 0));
+		Quat rotation = Quat::Slerp(ownerTransform->GetGlobalRotation(), targetRotation, rotationSlerpRatio * Time::GetDeltaTime());
+		ownerTransform->SetGlobalRotation(rotation);
 	}
 }
 

--- a/Penteract/Assets/Scripts/AIMovement.h
+++ b/Penteract/Assets/Scripts/AIMovement.h
@@ -26,7 +26,7 @@ public:
 
 public:
 	static int maxAcceleration;
-	float rotationSlerpRatio = 9.0f;
+	float rotationSmoothness = 9.0f;
 
 private:
 

--- a/Penteract/Assets/Scripts/AIMovement.h
+++ b/Penteract/Assets/Scripts/AIMovement.h
@@ -4,6 +4,8 @@
 
 #include "AIState.h"
 
+#include "Math/Quat.h"
+
 class ComponentTransform;
 class ComponentAgent;
 
@@ -24,9 +26,12 @@ public:
 
 public:
 	static int maxAcceleration;
+	float rotationSlerpRatio = 9.0f;
+
 private:
 
 	float3 velocity = float3(0, 0, 0);
+	Quat targetRotation = Quat(0, 0, 0, 1);
 	ComponentTransform* ownerTransform = nullptr;
 	ComponentAgent* agent = nullptr;
 };

--- a/Penteract/Assets/Scripts/AIMovement.h
+++ b/Penteract/Assets/Scripts/AIMovement.h
@@ -26,7 +26,7 @@ public:
 
 public:
 	static int maxAcceleration;
-	float rotationSmoothness = 9.0f;
+	float rotationSmoothness = 0.2f;
 
 private:
 


### PR DESCRIPTION
Enemies will now rotate towards where they are moving instead of looking at the player.
- New parameter for AIMovement: rotationSmoothness (Higher values mean smoother but slower rotation)