### PR TITLE
Initial & final door implementation + wave feature refactor

### DIFF
--- a/Penteract/Assets/Scripts/EnemySpawnPoint.cpp
+++ b/Penteract/Assets/Scripts/EnemySpawnPoint.cpp
@@ -7,6 +7,7 @@
 #include "WinLose.h"
 
 EXPOSE_MEMBERS(EnemySpawnPoint) {
+	MEMBER(MemberType::GAME_OBJECT_UID, playerUID),
 	MEMBER(MemberType::FLOAT, xAxisPos),
 	MEMBER(MemberType::FLOAT, zAxisPos),
 	MEMBER(MemberType::INT, offset),
@@ -20,7 +21,6 @@ EXPOSE_MEMBERS(EnemySpawnPoint) {
 	MEMBER(MemberType::INT, fourthWaveRangeAmount),
 	MEMBER(MemberType::INT, fifthWaveMeleeAmount),
 	MEMBER(MemberType::INT, fifthWaveRangeAmount),
-	MEMBER(MemberType::GAME_OBJECT_UID, playerUID)
 };
 
 GENERATE_BODY_IMPL(EnemySpawnPoint);
@@ -43,6 +43,7 @@ void EnemySpawnPoint::Start() {
 	if (spawnPointControllerScript) {
 		meleeEnemyPrefab = spawnPointControllerScript->GetMeleePrefab();
 		rangeEnemyPrefab = spawnPointControllerScript->GetRangePrefab();
+		spawnPointControllerScript->SetCurrentEnemyAmount(index, amountOfEnemies);
 	}
 
 	GameObject* player = GameplaySystems::GetGameObject(playerUID);
@@ -64,16 +65,17 @@ void EnemySpawnPoint::Update() {
 		/* Stop the spawn until all the wave enemies die */
 		spawn = false;
 		waveRemainingEnemies = std::get<0>(*it) + std::get<1>(*it);
+		spawnPointControllerScript->SetCurrentEnemyAmount(index, waveRemainingEnemies);
 	}
 
 	/* Condition to spawn the next wave */
-	if (waveRemainingEnemies == 0) {
+	if (waveRemainingEnemies == 0 && spawnPointControllerScript->CanSpawn()) {
 		spawn = true;
 		if (it != enemies.end()) {
 			it++;
 		}
 		else {
-			if (spawnPointControllerScript) spawnPointControllerScript->OpenDoor();
+			spawnPointControllerScript->SetEnemySpawnStatus(index, false);
 		}
 	}
 }
@@ -81,6 +83,7 @@ void EnemySpawnPoint::Update() {
 /* Called each time an enemy dies */
 void EnemySpawnPoint::UpdateRemainingEnemies() {
 	waveRemainingEnemies--;
+	spawnPointControllerScript->SetCurrentEnemyAmount(index, waveRemainingEnemies);
 }
 
 void EnemySpawnPoint::RenderEnemy(EnemyType type, unsigned int amount) {

--- a/Penteract/Assets/Scripts/EnemySpawnPoint.h
+++ b/Penteract/Assets/Scripts/EnemySpawnPoint.h
@@ -21,6 +21,8 @@ public:
 	void UpdateRemainingEnemies();
 	int GetAmountofEnemies() { return amountOfEnemies; };
 
+	void SetIndex(unsigned int _index) { index = _index; };
+
 public:
 	/* Wave configuration */
 	unsigned int firstWaveMeleeAmount = 0;
@@ -47,7 +49,6 @@ public:
 
 	/* Player */
 	UID playerUID = 0;
-
 
 private:
 	/* Owner */
@@ -79,6 +80,9 @@ private:
 
 	/* Parent script */
 	SpawnPointController* spawnPointControllerScript = nullptr;
+
+	/* Index to update the spawn controller */
+	unsigned int index = 0;
 
 private:
 	void RenderEnemy(EnemyType type, unsigned int amount);

--- a/Penteract/Assets/Scripts/SpawnPointController.cpp
+++ b/Penteract/Assets/Scripts/SpawnPointController.cpp
@@ -7,6 +7,7 @@
 EXPOSE_MEMBERS(SpawnPointController) {
 	MEMBER(MemberType::PREFAB_RESOURCE_UID, meleeEnemyPrefabUID),
 	MEMBER(MemberType::PREFAB_RESOURCE_UID, rangeEnemyPrefabUID),
+	MEMBER(MemberType::BOOL, unlocksInitialDoor),
 	MEMBER(MemberType::GAME_OBJECT_UID, initialDoorUID),
 	MEMBER(MemberType::GAME_OBJECT_UID, finalDoorUID),
 };
@@ -49,7 +50,7 @@ void SpawnPointController::OnCollision(GameObject& collidedWith, float3 collisio
 void SpawnPointController::OpenDoor() {
 	if (CheckSpawnPointStatus()) {
 		if (finalDoor && finalDoor->IsActive()) finalDoor->Disable();
-		if (initialDoor && initialDoor->IsActive()) initialDoor->Disable();
+		if (unlocksInitialDoor && initialDoor && initialDoor->IsActive()) initialDoor->Disable();
 		gameObject->Disable();
 	}
 }

--- a/Penteract/Assets/Scripts/SpawnPointController.cpp
+++ b/Penteract/Assets/Scripts/SpawnPointController.cpp
@@ -2,11 +2,13 @@
 
 #include "GameObject.h"
 #include "GameplaySystems.h"
+#include "EnemySpawnPoint.h"
 
 EXPOSE_MEMBERS(SpawnPointController) {
 	MEMBER(MemberType::PREFAB_RESOURCE_UID, meleeEnemyPrefabUID),
-		MEMBER(MemberType::PREFAB_RESOURCE_UID, rangeEnemyPrefabUID),
-		MEMBER(MemberType::GAME_OBJECT_UID, doorUID),
+	MEMBER(MemberType::PREFAB_RESOURCE_UID, rangeEnemyPrefabUID),
+	MEMBER(MemberType::GAME_OBJECT_UID, initialDoorUID),
+	MEMBER(MemberType::GAME_OBJECT_UID, finalDoorUID),
 };
 
 GENERATE_BODY_IMPL(SpawnPointController);
@@ -18,7 +20,17 @@ void SpawnPointController::Start() {
 	meleeEnemyPrefab = GameplaySystems::GetResource<ResourcePrefab>(meleeEnemyPrefabUID);
 	rangeEnemyPrefab = GameplaySystems::GetResource<ResourcePrefab>(rangeEnemyPrefabUID);
 
-	doorObstacle = GameplaySystems::GetGameObject(doorUID);
+	initialDoor = GameplaySystems::GetGameObject(initialDoorUID);
+	finalDoor = GameplaySystems::GetGameObject(finalDoorUID);
+
+	unsigned int i = 0;
+	for (GameObject* child : gameObject->GetChildren()) {
+		EnemySpawnPoint* childScript = GET_SCRIPT(child, EnemySpawnPoint);
+		if (childScript) childScript->SetIndex(i);
+		enemiesPerSpawnPoint.push_back(0);
+		enemySpawnPointStatus.push_back(true);
+		++i;
+	}
 }
 
 void SpawnPointController::Update() {}
@@ -28,10 +40,33 @@ void SpawnPointController::OnCollision(GameObject& collidedWith, float3 collisio
 	for (GameObject* child : gameObject->GetChildren()) {
 		if (!child->IsActive()) child->Enable();
 	}
+	if (initialDoor && !initialDoor->IsActive()) initialDoor->Enable();
+	if (finalDoor && !finalDoor->IsActive()) finalDoor->Enable();
 	ComponentBoxCollider* boxCollider = gameObject->GetComponent<ComponentBoxCollider>();
 	if (boxCollider) boxCollider->Disable();
 }
 
 void SpawnPointController::OpenDoor() {
-	if (doorObstacle && doorObstacle->IsActive()) doorObstacle->Disable();
+	if (CheckSpawnPointStatus()) {
+		if (finalDoor && finalDoor->IsActive()) finalDoor->Disable();
+		if (initialDoor && initialDoor->IsActive()) initialDoor->Disable();
+		gameObject->Disable();
+	}
+}
+
+void SpawnPointController::SetCurrentEnemyAmount(unsigned int pos, unsigned int amount) {
+	enemiesPerSpawnPoint[pos] = amount;
+}
+
+void SpawnPointController::SetEnemySpawnStatus(unsigned int pos, bool status) {
+	enemySpawnPointStatus[pos] = status;
+	if (!status) OpenDoor();
+}
+
+bool SpawnPointController::CanSpawn() {
+	return std::all_of(enemiesPerSpawnPoint.begin(), enemiesPerSpawnPoint.end(), [](unsigned int i) { return i == 0; });
+}
+
+bool SpawnPointController::CheckSpawnPointStatus() {
+	return std::all_of(enemySpawnPointStatus.begin(), enemySpawnPointStatus.end(), [](bool i) { return !i; });;
 }

--- a/Penteract/Assets/Scripts/SpawnPointController.h
+++ b/Penteract/Assets/Scripts/SpawnPointController.h
@@ -2,6 +2,8 @@
 
 #include "Scripting/Script.h"
 
+#include <vector>
+
 class GameObject;
 class ResourcePrefab;
 
@@ -14,7 +16,8 @@ public:
 	UID rangeEnemyPrefabUID = 0;
 
 	/* Door UID */
-	UID doorUID = 0;
+	UID initialDoorUID = 0;
+	UID finalDoorUID = 0;
 
 public:
 	void Start() override;
@@ -27,6 +30,11 @@ public:
 	ResourcePrefab* GetMeleePrefab() { return meleeEnemyPrefab; };
 	ResourcePrefab* GetRangePrefab() { return rangeEnemyPrefab; };
 
+	/* Spawn point status for wave management */
+	void SetCurrentEnemyAmount(unsigned int pos, unsigned int amount);
+	void SetEnemySpawnStatus(unsigned int pos, bool status);
+	bool CanSpawn();
+
 private:
 	/* Owner */
 	GameObject* gameObject = nullptr;
@@ -36,5 +44,13 @@ private:
 	ResourcePrefab* rangeEnemyPrefab = nullptr;
 
 	/* Door object */
-	GameObject* doorObstacle = nullptr;
+	GameObject* initialDoor = nullptr;
+	GameObject* finalDoor = nullptr;
+
+	/* Spawn points satus*/
+	std::vector<unsigned int> enemiesPerSpawnPoint;
+	std::vector<bool> enemySpawnPointStatus;
+
+private:
+	bool CheckSpawnPointStatus();
 };

--- a/Penteract/Assets/Scripts/SpawnPointController.h
+++ b/Penteract/Assets/Scripts/SpawnPointController.h
@@ -19,6 +19,8 @@ public:
 	UID initialDoorUID = 0;
 	UID finalDoorUID = 0;
 
+	bool unlocksInitialDoor = true;
+
 public:
 	void Start() override;
 	void Update() override;


### PR DESCRIPTION
As Yago requested:
- The spawn points now have an initial door to close when the encounter starts
- The waves of all the spawn points are related so they all spawn the same one until all the enemies are dead they go to the next one