### PR TITLE
Feature/melee dissolve and onimaru shield hit

### DIFF
--- a/Penteract/Assets/Scripts/AIMeleeGrunt.cpp
+++ b/Penteract/Assets/Scripts/AIMeleeGrunt.cpp
@@ -157,7 +157,7 @@ void AIMeleeGrunt::Update() {
 		if (timeSinceLastHurt < hurtFeedbackTimeDuration) {
 			timeSinceLastHurt += Time::GetDeltaTime();
 			if (timeSinceLastHurt > hurtFeedbackTimeDuration) {
-				componentMeshRenderer->materialId = defaultMaterialID;
+				SetMaterial(defaultMaterialID);
 			}
 		}
 	}
@@ -540,19 +540,16 @@ void AIMeleeGrunt::PlayerHit() {
 
 void AIMeleeGrunt::PlayHitMaterialEffect()
 {
-	if (!dissolveAlreadyStarted && componentMeshRenderer) {
-		if (damageMaterialID != 0) {
-			componentMeshRenderer->materialId = damageMaterialID;
-		}
+	if (!dissolveAlreadyStarted) {
+		SetMaterial(damageMaterialID);
 	}
 }
 
 void AIMeleeGrunt::UpdateDissolveTimer() {
 	if (dissolveAlreadyStarted && !dissolveAlreadyPlayed) {
 		if (currentDissolveTime >= dissolveTimerToStart) {
-			if (componentMeshRenderer && dissolveMaterialID != 0) {
-				componentMeshRenderer->materialId = dissolveMaterialID;
-				componentMeshRenderer->PlayDissolveAnimation();
+			if (dissolveMaterialID != 0) {
+				SetMaterial(dissolveMaterialID, true);
 			}
 			dissolveAlreadyPlayed = true;
 		}
@@ -592,6 +589,17 @@ void AIMeleeGrunt::SetRandomMaterial()
 						mesh.materialId = materials[position];
 					}
 				}
+			}
+		}
+	}
+}
+
+void AIMeleeGrunt::SetMaterial(UID newMaterialID, bool needToPlayDissolve) {
+	if (newMaterialID > 0 && GetOwner().GetChildren().size() > 0) {
+		for (ComponentMeshRenderer& mesh : GetOwner().GetChildren()[0]->GetComponents<ComponentMeshRenderer>()) {
+			mesh.materialId = newMaterialID;
+			if (needToPlayDissolve) {
+				mesh.PlayDissolveAnimation();
 			}
 		}
 	}

--- a/Penteract/Assets/Scripts/AIMeleeGrunt.h
+++ b/Penteract/Assets/Scripts/AIMeleeGrunt.h
@@ -145,4 +145,5 @@ private:
 	void PlayHitMaterialEffect();
 	void UpdateDissolveTimer();
 	void SetRandomMaterial();
+	void SetMaterial(UID newMaterialID, bool needToPlayDissolve = false);
 };

--- a/Penteract/Assets/Scripts/Shield.cpp
+++ b/Penteract/Assets/Scripts/Shield.cpp
@@ -5,6 +5,7 @@
 #include "PlayerController.h"
 #include "RangerProjectileScript.h"
 #include "Components/Physics/ComponentSphereCollider.h"
+#include "Components/ComponentAudioSource.h"
 #include "Math/float3.h"
 
 EXPOSE_MEMBERS(Shield) {
@@ -21,6 +22,7 @@ void Shield::Start() {
 	currentAvailableCharges = maxCharges;
 	GameObject* playerGO = GameplaySystems::GetGameObject(playerUID);
 	if (playerGO) playerController = GET_SCRIPT(playerGO, PlayerController);
+	audio = GetOwner().GetComponent<ComponentAudioSource>();
 }
 
 void Shield::Update() {}
@@ -35,7 +37,7 @@ void Shield::FadeShield() {
 
 void Shield::OnCollision(GameObject& collidedWith, float3 collisionNormal, float3 penetrationDistance, void* particle) {
 	if ((collidedWith.name == "RangerProjectile" || collidedWith.name == "MeleePunch") && isActive && playerController) {
-		if (playerController->playerOnimaru.level1Upgrade && collidedWith.name == "RangerProjectile") {
+		if (playerController->playerOnimaru.level1Upgrade && collidedWith.name == "RangerProjectile") {		// Reflect projectile
 			ComponentSphereCollider* sCollider = collidedWith.GetComponent<ComponentSphereCollider>();
 			if (!sCollider) return;
 			RangerProjectileScript* rps = GET_SCRIPT(&collidedWith, RangerProjectileScript);
@@ -58,5 +60,9 @@ void Shield::OnCollision(GameObject& collidedWith, float3 collisionNormal, float
 			GameplaySystems::DestroyGameObject(&collidedWith);
 		}
 		currentAvailableCharges--;
+		
+		if (audio) {		// Play hit effect
+			audio->Play();
+		}
 	}
 }

--- a/Penteract/Assets/Scripts/Shield.h
+++ b/Penteract/Assets/Scripts/Shield.h
@@ -3,6 +3,7 @@
 #include "Scripting/Script.h"
 
 class PlayerController;
+class ComponentAudioSource;
 
 class Shield : public Script
 {
@@ -34,5 +35,6 @@ public:
 
 private:
 	bool isActive = false;
+	ComponentAudioSource* audio;
 
 };


### PR DESCRIPTION
An audio can be played on Onimaru's Shield hit. It needs to have a ComponentAudioSource on VFXShield.
Melee correctly dissolves all meshes and changes their material when hit.