### PR TITLE
Fix Onimaru shoot+ult simultaneously

### DIFF
--- a/Penteract/Assets/Scripts/Onimaru.cpp
+++ b/Penteract/Assets/Scripts/Onimaru.cpp
@@ -517,7 +517,7 @@ void Onimaru::Update(bool useGamepad, bool lockMovement, bool lockRotation) {
 			}
 		}
 		else {
-			//Ultimate execution
+			// Ultimate execution
 			if (ultimateTimeRemaining > 0) {
 				ultimateTimeRemaining -= Time::GetDeltaTime();
 				Shoot();


### PR DESCRIPTION
Whithout releasing the mouse click to continue shooting,
you could Ultimate with Onimaru, and the shooting particles and sounds would not stop,
having the ultimate and the normal shot particles at the same time.

Fixed that.

As an involuntary feature, now if you hold the shooting button when pressing ult, and you hold it until the end of the ult, Onimaru will start shooting right away when it finishes, which seems kind of fluid and cool.