### PR TITLE
Scene2 Gamepad textures and hierarchy set.

### DIFF
--- a/Penteract/Assets/Scripts/GameController.cpp
+++ b/Penteract/Assets/Scripts/GameController.cpp
@@ -349,5 +349,5 @@ void GameController::EnablePauseMenus() {
 }
 
 bool GameController::CanPause() {
-	return /*!GameplaySystems::GetGlobalVariable(isVideoActive, true) &&*/ (!playerController || playerController && !playerController->IsPlayerDead());
+	return !GameplaySystems::GetGlobalVariable(isVideoActive, true) && (!playerController || playerController && !playerController->IsPlayerDead());
 }

--- a/Penteract/Assets/Scripts/GameController.cpp
+++ b/Penteract/Assets/Scripts/GameController.cpp
@@ -42,11 +42,13 @@ EXPOSE_MEMBERS(GameController) {
 GENERATE_BODY_IMPL(GameController);
 
 void GameController::Start() {
+	Debug::Log("Start");
 	isPaused = false;
 	showWireframe = false;
 	transitionFinished = false;
 	GameplaySystems::SetGlobalVariable(globalIsGameplayBlocked, false);
 	GameplaySystems::SetGlobalVariable(globalswitchTutorialActive, false);
+	GameplaySystems::SetGlobalVariable(globalBackDetectionInUse, false);
 
 	if (PlayerController::currentLevel == 1) {
 		GameplaySystems::SetGlobalVariable(globalSkill1TutorialReached, false);
@@ -135,8 +137,11 @@ void GameController::Update() {
 
 	if (CanPause()) {
 		if (isPaused) {
-			if (Player::GetInputBool(InputActions::CANCEL_A) || Player::GetInputBool(InputActions::CANCEL_B))
-				ResumeGame();
+			if (Player::GetInputBool(InputActions::CANCEL_A) || Player::GetInputBool(InputActions::CANCEL_B)) {
+				if (!GameplaySystems::GetGlobalVariable(globalBackDetectionInUse,false)) { //globalBackDetectionInUse determines if cancel buttons must do navigation stuff or just UnPause
+					ResumeGame();
+				}
+			}
 		} else {
 			if (Player::GetInputBool(InputActions::CANCEL_A))
 				PauseGame();
@@ -344,5 +349,5 @@ void GameController::EnablePauseMenus() {
 }
 
 bool GameController::CanPause() {
-	return !GameplaySystems::GetGlobalVariable(isVideoActive, true) && (!playerController || playerController && !playerController->IsPlayerDead());
+	return /*!GameplaySystems::GetGlobalVariable(isVideoActive, true) &&*/ (!playerController || playerController && !playerController->IsPlayerDead());
 }

--- a/Penteract/Assets/Scripts/GlobalVariables.h
+++ b/Penteract/Assets/Scripts/GlobalVariables.h
@@ -17,5 +17,5 @@ constexpr const char* globalSkill2TutorialReachedOni = "Skill2ReachedOni";	// Bl
 constexpr const char* globalSkill3TutorialReachedOni = "Skill3ReachedOni";	// Oni Ultimate
 constexpr const char* globalswitchTutorialActive = "IsSwitchTutorialActive";	// This overrides globalSwitchTutorialReached on Fang's 'CanSwitch()', used when the Switch Tutorial appears to allow the use of the Switch then.
 
-
+constexpr const char* globalBackDetectionInUse = "BackDetectionInUse"; //globalBackDetectionInUse determines if cancel buttons must do navigation stuff or just UnPause, a UINavigationBackDetection script with nullreferences should only be found on the resume button, thus only with that button calling ONEnable should this be set to false
 constexpr const char* globalUseGamepad = "UseGamepad";

--- a/Penteract/Assets/Scripts/UINavigationBackDetection.cpp
+++ b/Penteract/Assets/Scripts/UINavigationBackDetection.cpp
@@ -53,4 +53,11 @@ void UINavigationBackDetection::OnEnable() {
 			evSyst->SetSelected(selectableToSelectOnEnable->GetID());
 		}
 	}
+
+	if (objectToDisableOnCancel != nullptr) {
+		GameplaySystems::SetGlobalVariable(globalBackDetectionInUse, true);
+	} else {
+		GameplaySystems::SetGlobalVariable(globalBackDetectionInUse, false);
+	}
+
 }


### PR DESCRIPTION
Fixed a minor Dialogue bug on Scene2 that made flash not visible
Established a globalVariable to make cancel button make navigation actions instead of unpausing. Unpausing can now only happen from the General Pause view, where the only UINavigationBackDetection script with nullreferences assigned to objectToDisableOnCancel exists on all scenes